### PR TITLE
Add bash completion for long options and package names

### DIFF
--- a/bash_completion
+++ b/bash_completion
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+_burgaur() {
+    local cur=${COMP_WORDS[COMP_CWORD]}
+    local prev=${COMP_WORDS[COMP_CWORD - 1]}
+    local longopts=(--color --force-update --make-install --noconfirm --noinstall --system-update
+		    --cower-raw-options --help --nobuild --nodelete --search-install --version)
+
+    case $cur in
+	--*)
+	    COMPREPLY=($(compgen -W '${longopts[*]}' -- "$cur"))
+	;;
+    esac
+
+    case $prev in
+	-fu|--force-update)
+	    COMPREPLY=($(compgen -W '$(pacman -Qqm 2>/dev/null)' -- "$cur"))
+	    return 0
+	    ;;
+	-mi|--make-install|-si|--search-install)
+	    COMPREPLY=($(compgen -W "$(cower -sq -- "$cur" 2>/dev/null)" -- "$cur"))
+	    return 0
+	    ;;
+    esac
+}
+
+complete -F _burgaur burgaur

--- a/misc/PKGBUILD
+++ b/misc/PKGBUILD
@@ -32,6 +32,7 @@ package() {
   python setup.py install --root="${pkgdir}/"
   install -Dm644 burgaur.1.gz "${pkgdir}/usr/share/man/man1/burgaur.1.gz"
   install -Dm644 LICENSE "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+  install -Dm644 bash_completion "${pkgdir}/usr/share/bash-completion/completions/burgaur"
 }
 
 # vim: ts=8 et sw=2 sts=2

--- a/misc/PKGBUILD.stable
+++ b/misc/PKGBUILD.stable
@@ -20,6 +20,7 @@ package() {
   python setup.py install --root="${pkgdir}/"
   install -Dm644 burgaur.1.gz "${pkgdir}/usr/share/man/man1/burgaur.1.gz"
   install -Dm644 LICENSE "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+  install -Dm644 bash_completion "${pkgdir}/usr/share/bash-completion/completions/burgaur"
 }
 
 # vim: ts=8 et sw=2 sts=2


### PR DESCRIPTION
The one thing I miss in burgaur that cower has is the bash completion for package names, so this PR adds it in.

I'm pretty much doing the same as cower's tab completion:
--force-update completes with all the foreign packages installed
--make-install and --search-install completes with an AUR search using cower